### PR TITLE
👍 update:ホーム画面にプリセット一覧を表示する処理を追加

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,61 @@
+// 初期化処理(プリセットの読み込み)
+const initialPresets = {
+    "monday": ["ノート", "ペン"],
+    "tuesday": ["教科書", "消しゴム"],
+    "wednesday": ["PC", "マウス"],
+    "thursday": ["資料", "USB"],
+    "friday": ["スケッチブック", "カラーペン"]
+};
+
+// 初期データをlocalStorageに保存
+function setInitialPresets() {
+    for (const [day, items] of Object.entries(initialPresets)) {
+        if (!localStorage.getItem(day)) {
+            localStorage.setItem(day, JSON.stringify(items));
+        }
+    }
+}
+
+// 曜日リストを表示
+function displayPresets() {
+    const selectListDiv = document.querySelector(".selectList");
+
+    // 現在の曜日を取得
+    const currentDay = getCurrentDay();
+
+    // 曜日ごとボタンを作成
+    for (const day of Object.keys(initialPresets)) {
+        const dayDiv = document.createElement("div");
+        dayDiv.className = "preset";
+
+        //現在の曜日をハイライト
+        const isToday = day === currentDay ? "highlight" : "";
+
+        dayDiv.innerHTML = `
+            <button class="select-button ${isToday}" data-day="${day}">${day}</button>
+        `;
+        selectListDiv.appendChild(dayDiv);
+    }
+
+    // 曜日ボタンにクリックイベントを追加
+    document.querySelectorAll(".select-button").forEach(button => {
+        button.addEventListener("click", (event) => {
+            const day = event.target.getAttribute("data-day");
+            // 曜日情報をクエリパラメータとして渡す
+            window.location.href = `src/html/check_list.html?day=${day}`;
+        })
+    })
+}
+
+// 現在の曜日を取得する関数
+function getCurrentDay() {
+    const days = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+    const today = new Date().getDay();
+    return days[today];
+}
+
+// DOMが完全に読み込まれたら初期化処理を実行
+document.addEventListener("DOMContentLoaded", () => {
+    setInitialPresets();
+    displayPresets();
+});

--- a/public/style.css
+++ b/public/style.css
@@ -51,3 +51,35 @@ a.add {
 a.add:hover {
     background-color: #218838;
 }
+
+div.selectList {
+    margin: 2em auto;
+    max-width: 600px;
+    text-align: center;
+}
+
+div.preset {
+    margin: 1em 0;
+}
+
+button.select-button {
+    padding: 0.8em 1.5em;
+    font-size: 1em;
+    border: none;
+    border-radius: 5px;
+    background-color: #6c757d;
+    color: white;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+button.select-button:hover {
+    background-color: #5a6268;
+}
+
+button.select-button.highlight {
+    background-color: #ffc107;
+    color: #343a40;
+    font-weight: bold;
+    border: 2px solid #e0a800;
+}


### PR DESCRIPTION
## 概要

仮UIにプリセット一覧を表示する処理を追加
プリセット一覧はlocalStorageで保持し，そこから取得して表示する

**変更内容**
- ```script.js```にプリセットの初期化処理，曜日リスト(プリセットリスト)の表示，曜日の取得処理の追加
- 曜日に応じてハイライトを表示
- 選択したプリセットに応じてクエリパラメータを付与して選択プリセットを識別

## 関連

## テスト方法

```index.html```(最初に表示されるページ)にアクセスしてリストの表示，クエリパラメータの付与，ハイライト化の確認

## レビュアーチェックリスト
